### PR TITLE
Update parse.h

### DIFF
--- a/src/parse.h
+++ b/src/parse.h
@@ -25,6 +25,7 @@
 #ifndef PARSE_H
 #define PARSE_H
 
+#include <cstdio>
 #include <map>
 #include <vector>
 #include "rapidxml/rapidxml.hpp"


### PR DESCRIPTION
Add header cstdio to use printf. I had a compilation error because of its absence.